### PR TITLE
Small fixes on karm-math and scene.

### DIFF
--- a/src/libs/karm-math/ellipse.h
+++ b/src/libs/karm-math/ellipse.h
@@ -55,7 +55,7 @@ union Ellipse {
     }
 
     template <typename U>
-    constexpr Ellipse<U> cast() {
+    constexpr Ellipse<U> cast() const {
         return {center.template cast<U>(), radii.template cast<U>()};
     }
 

--- a/src/libs/karm-math/path.cpp
+++ b/src/libs/karm-math/path.cpp
@@ -257,48 +257,55 @@ void Path::evalOp(Op op) {
     case CLOSE:
         op.p = _verts[last(_contours).start];
         _flattenClose();
+        _lastCp = op.p;
         break;
 
     case MOVE_TO:
         _contours.pushBack({_verts.len(), _verts.len(), false});
         _flattenLineTo(op.p);
+        _lastCp = op.p;
         break;
 
     case LINE_TO:
         _flattenLineTo(op.p);
+        _lastCp = op.p;
         break;
 
     case HLINE_TO:
         op.p = {op.p.x, _lastP.y};
         _flattenLineTo(op.p);
+        _lastCp = op.p;
         break;
 
     case VLINE_TO:
         op.p = {_lastP.x, op.p.y};
         _flattenLineTo(op.p);
+        _lastCp = op.p;
         break;
 
     case CUBIC_TO:
         if (op.flags & SMOOTH)
             op.cp1 = _lastP * 2 - _lastCp;
         _flattenCurveTo(Math::Curvef::cubic(_lastP, op.cp1, op.cp2, op.p));
+        _lastCp = op.cp2;
         break;
 
     case QUAD_TO:
         if (op.flags & SMOOTH)
             op.cp2 = _lastP * 2 - _lastCp;
         _flattenCurveTo(Math::Curvef::quadratic(_lastP, op.cp2, op.p));
+        _lastCp = op.cp2;
         break;
 
     case ARC_TO:
         _flattenArcTo(_lastP, op.radii, op.angle, op.flags, op.p);
+        _lastCp = op.p;
         break;
 
     default:
         panic("unknown path opcode");
     }
 
-    _lastCp = op.cp2;
     _lastP = op.p;
 }
 

--- a/src/libs/karm-math/path.cpp
+++ b/src/libs/karm-math/path.cpp
@@ -73,12 +73,15 @@ Math::Rectf Path::bound() {
 // MARK: Flattening ------------------------------------------------------------
 
 void Path::_flattenClose() {
-    auto end = _verts[last(_contours).end - 1];
-    auto start = _verts[last(_contours).start];
-
-    if (Math::epsilonEq(start, end, 0.001)) {
-        _verts.popBack();
-        last(_contours).end--;
+    if(_contours.len() > 1){
+        auto end = _verts[last(_contours).end - 1];
+        auto start = _verts[last(_contours).start];
+    
+        // NOTE: remove last edge if it is manually closing the path, since 'z' should be the one closing
+        if (Math::epsilonEq(start, end, 0.001)) {
+            _verts.popBack();
+            last(_contours).end--;
+        }
     }
 
     last(_contours).close = true;
@@ -448,6 +451,9 @@ void Path::arc(Math::Arcf arc) {
 
 void Path::path(Math::Path const& path) {
     for (auto contour : path.iterContours()) {
+        if (contour.len() == 0)
+            panic("it is not possible to have an empty contour at this point");
+
         moveTo(first(contour));
         for (auto v : next(contour, 1)) {
             lineTo(v);

--- a/src/libs/karm-math/tests/test-trans.cpp
+++ b/src/libs/karm-math/tests/test-trans.cpp
@@ -4,16 +4,85 @@
 namespace Karm::Math::Tests {
 
 test$("transform-inverse") {
-    Vec2<double> transVec{1.0, 2.0};
+    Vec2<f64> v{1.0, 2.0};
 
     auto makeIdentity = [](Trans2f m) {
         return m.multiply(m.inverse());
     };
 
     expect$(makeIdentity(Trans2f::rotate(10)).isIdentity());
-    expect$(makeIdentity(Trans2f::skew(transVec)).isIdentity());
-    expect$(makeIdentity(Trans2f::scale(transVec)).isIdentity());
-    expect$(makeIdentity(Trans2f::translate(transVec)).isIdentity());
+    expect$(makeIdentity(Trans2f::skew(v)).isIdentity());
+    expect$(makeIdentity(Trans2f::scale(v)).isIdentity());
+    expect$(makeIdentity(Trans2f::translate(v)).isIdentity());
+    expect$(makeIdentity(Trans2f::rotate(Math::PI / 2.0).translated(v / 2.0)).isIdentity());
+    expect$(makeIdentity(Trans2f::translate(v).rotated(Math::PI / 2.0)).isIdentity());
+
+    return Ok();
+}
+
+test$("transform-basics") {
+    Vec2<f64> a{1.0, 0.0};
+    Vec2<f64> b{0.0, 1.0};
+    Vec2<f64> c{1.0, 1.0};
+
+    expectEq$(Trans2f::translate({0.0, 0.0}).apply(a), a);
+    expectEq$(Trans2f::translate({1.0, 1.0}).apply(a), (Vec2<f64>{2.0, 1.0}));
+    expectEq$(Trans2f::translate({-1.0, -1.0}).apply(a), (Vec2<f64>{0.0, -1.0}));
+
+    expectEq$(Trans2f::translate({0.0, 0.0}).apply(b), b);
+    expectEq$(Trans2f::translate({1.0, 1.0}).apply(b), (Vec2<f64>{1.0, 2.0}));
+    expectEq$(Trans2f::translate({-1.0, -1.0}).apply(b), (Vec2<f64>{-1.0, 0.0}));
+
+    expectEq$(Trans2f::scale({2.0, 0.0}).apply(a), (Vec2<f64>{2.0, 0.0}));
+    expectEq$(Trans2f::scale({0.0, 0.0}).apply(a), (Vec2<f64>{0.0, 0.0}));
+    expectEq$(Trans2f::scale({1.0, 1.0}).apply(a), a);
+
+    expectEq$(Trans2f::scale({0.0, 2.0}).apply(b), (Vec2<f64>{0.0, 2.0}));
+    expectEq$(Trans2f::scale({0.0, 0.0}).apply(b), (Vec2<f64>{0.0, 0.0}));
+    expectEq$(Trans2f::scale({1.0, 1.0}).apply(b), b);
+
+    expectEq$(Trans2f::scale({2.0, 2.0}).apply(c), (Vec2<f64>{2.0, 2.0}));
+    expectEq$(Trans2f::scale({1.0, 1.0}).apply(c), c);
+    expectEq$(Trans2f::scale({0.0, 0.0}).apply(c), (Vec2<f64>{0.0, 0.0}));
+    expectEq$(Trans2f::scale({-1.0, -1.0}).apply(c), (Vec2<f64>{-1.0, -1.0}));
+
+    return Ok();
+}
+
+test$("transform-composite-1") {
+    Vec2<f64> a{1.0, 0.0};
+    Vec2<f64> b{0.0, 1.0};
+    Vec2<f64> c{1.0, 1.0};
+
+    auto m1 = Trans2f::translate({1.0, 1.0}).scaled({2.0, 2.0});
+    auto m2 = Trans2f::scale({2.0, 2.0}).translated({1.0, 1.0});
+
+    expectEq$(m1.apply(a), (Vec2<f64>{4.0, 2.0}));
+    expectEq$(m1.apply(b), (Vec2<f64>{2.0, 4.0}));
+    expectEq$(m1.apply(c), (Vec2<f64>{4.0, 4.0}));
+
+    expectEq$(m2.apply(a), (Vec2<f64>{3.0, 1.0}));
+    expectEq$(m2.apply(b), (Vec2<f64>{1.0, 3.0}));
+    expectEq$(m2.apply(c), (Vec2<f64>{3.0, 3.0}));
+
+    return Ok();
+}
+
+test$("transform-composite-2") {
+    Vec2<f64> a{1.0, 0.0};
+    Vec2<f64> b{0.0, 1.0};
+    Vec2<f64> c{1.0, 1.0};
+
+    auto m1 = Trans2f::translate({1.0, 1.0}).rotated(Math::PI / 2.0);
+    auto m2 = Trans2f::rotate(Math::PI / 2.0).translated({1.0, 1.0});
+
+    expectEq$(m1.apply(a), (Vec2<f64>{-1.0, 2.0}));
+    expectEq$(m1.apply(b), (Vec2<f64>{-2.0, 1.0}));
+    expectEq$(m1.apply(c), (Vec2<f64>{-2.0, 2.0}));
+
+    expectEq$(m2.apply(a), (Vec2<f64>{1.0, 2.0}));
+    expectEq$(m2.apply(b), (Vec2<f64>{0.0, 1.0}));
+    expectEq$(m2.apply(c), (Vec2<f64>{0.0, 2.0}));
 
     return Ok();
 }

--- a/src/libs/karm-math/trans.h
+++ b/src/libs/karm-math/trans.h
@@ -191,8 +191,8 @@ union Trans2 {
         return {
             yy / det, -xy / det,
             -yx / det, xx / det,
-            -(ox * yy - oy * xy) / det,
-            -(oy * xx - ox * yx) / det
+            -(ox * yy - oy * yx) / det,
+            -(oy * xx - ox * xy) / det
         };
     }
 


### PR DESCRIPTION
I would say that the fix proposed for path's last control point is not ideal due to how OP is coded now:
> Why all OPs have control points? would it make sense to make them Opts and add a getControlPoint() getter which would put `op.p` in case of a missing `op.cp2`?

Also in the node's paint rect commit, I didn't do any translation which is done when rendering in the browser. I don't know what the expected behaviour should be.