### PR TITLE
fix missing line return

### DIFF
--- a/src/libs/karm-pdf/values-impl.cpp
+++ b/src/libs/karm-pdf/values-impl.cpp
@@ -95,7 +95,7 @@ Res<> File::write(Io::Writer& w) const {
     e("trailer\n");
     trailer.write(e);
 
-    e("startxref\n");
+    e("\nstartxref\n");
     e("{}\n", startxref);
     e("%%EOF");
 


### PR DESCRIPTION
Add a \n to fix the compliance of the pdf on some pdf reader like pypdf