### PR TITLE
perf: improve performance by adding a fast path to blitUnsafe

### DIFF
--- a/src/libs/karm-gfx/buffer.cpp
+++ b/src/libs/karm-gfx/buffer.cpp
@@ -2,6 +2,8 @@ module;
 
 #include <karm-math/rect.h>
 
+#include "cstring"
+
 export module Karm.Gfx:buffer;
 
 import Karm.Core;
@@ -321,6 +323,13 @@ export struct Surface {
 export [[gnu::flatten]] void blitUnsafe(MutPixels dst, Pixels src) {
     if (dst.width() != src.width() or dst.height() != src.height()) [[unlikely]]
         panic("blitUnsafe() called with buffers of different sizes");
+
+    // HACK: fast path if the stride and fmt are the same
+    if (dst.stride() == src.stride() && (dst.fmt().index() == src.fmt().index()))
+    {
+            memcpy(dst._buf, src._buf,  src._stride * src.height() * sizeof(u8));
+            return;
+    }
 
     dst._fmt.visit([&](auto fd) {
         src._fmt.visit([&](auto fs) {

--- a/src/libs/karm-gfx/buffer.cpp
+++ b/src/libs/karm-gfx/buffer.cpp
@@ -2,8 +2,6 @@ module;
 
 #include <karm-math/rect.h>
 
-#include "cstring"
-
 export module Karm.Gfx:buffer;
 
 import Karm.Core;
@@ -325,10 +323,10 @@ export [[gnu::flatten]] void blitUnsafe(MutPixels dst, Pixels src) {
         panic("blitUnsafe() called with buffers of different sizes");
 
     // HACK: fast path if the stride and fmt are the same
-    if (dst.stride() == src.stride() && (dst.fmt().index() == src.fmt().index()))
+    if (dst.stride() == src.stride() and dst.fmt().index() == src.fmt().index())
     {
-            memcpy(dst._buf, src._buf,  src._stride * src.height() * sizeof(u8));
-            return;
+        std::memcpy(dst._buf, src._buf, src._stride * src.height() * sizeof(u8));
+        return;
     }
 
     dst._fmt.visit([&](auto fd) {


### PR DESCRIPTION
Performance in default configuration are now:
Average frame time old: 93.316520 fps
Average frame time new: 98.684211 fps
Average frame time old (peak): 36.474164 fps
Average frame time new (peak): 41.522491 fps

Note that (peak) frame time define fps which are below 60fps.
 
Improvement: + $5.7\\% \pm 0.1 \\%$ (fps)
Improvement: + $13.8 \\% \pm 0.3 \\%$ (fps)  [peak]